### PR TITLE
Add id attribute for fieldset (group), useful for group toggling.

### DIFF
--- a/@form.latte
+++ b/@form.latte
@@ -10,7 +10,7 @@
 {block #body}
     {* controls with group *}
     {foreach $renderer->findGroups() as $group}{block #group}
-        <fieldset>
+        <fieldset{if isset($group->id)} id="{$group->id}"{/if}>
             <legend n:if="$group->label">{$group->label}</legend>
             <p n:if="$group->description">{$group->description}</p>
 

--- a/BootstrapRenderer.php
+++ b/BootstrapRenderer.php
@@ -1,8 +1,11 @@
 <?php
+
 /**
- * This file has been created within Animal Group
+ * This file is part of the Kdyby (http://www.kdyby.org)
  *
- * @copyright Animal Group
+ * Copyright (c) 2008, 2012 Filip Procházka (filip.prochazka@kdyby.org)
+ *
+ * For the full copyright and license information, please view the file license.txt that was distributed with this source code.
  */
 
 namespace Kdyby\Extension\Forms\BootstrapRenderer;
@@ -90,7 +93,7 @@ class BootstrapRenderer extends Nette\Object implements Nette\Forms\IFormRendere
 			}
 
 			$formEl = $form->getElementPrototype();
-			if (stripos('form-', $formEl->class) === FALSE) {
+			if (!$formEl->class || stripos('form-', (string)$formEl->class) === FALSE) {
 				$formEl->addClass('form-horizontal');
 			}
 		}
@@ -260,6 +263,7 @@ class BootstrapRenderer extends Nette\Object implements Nette\Forms\IFormRendere
 
 		$groupLabel = $group->getOption('label');
 		$groupDescription = $group->getOption('description');
+		$groupID = $group->getOption('id');
 
 		// If we have translator, translate!
 		if ($translator = $this->form->getTranslator()) {
@@ -282,6 +286,7 @@ class BootstrapRenderer extends Nette\Object implements Nette\Forms\IFormRendere
 				}),
 			'label' => $groupLabel,
 			'description' => $groupDescription,
+			'id' => $groupID,
 		);
 	}
 


### PR DESCRIPTION
Useful for toggling particular groups, for example:

$form->addRadioList('radio', 'Select', array(
1 => 'Group 1',
2 => 'Group 2'))
->addCondition(Form::EQUAL, 1)
->toggle('group1')
->addCondition(Form::EQUAL, 2)
->toggle('group2');

$form->addGroup('Group 1')->setOption('id', 'group1');
$form->addGroup('Group 2')->setOption('id', 'group2');

etc.
