### PR TITLE
Made input prepend for email field optional

### DIFF
--- a/src/Kdyby/BootstrapFormRenderer/BootstrapRenderer.php
+++ b/src/Kdyby/BootstrapFormRenderer/BootstrapRenderer.php
@@ -170,7 +170,9 @@ class BootstrapRenderer extends Nette\Object implements Nette\Forms\IFormRendere
 			$el->placeholder($placeholder);
 		}
 
-		if ($control->controlPrototype->type === 'email') {
+		if ($control->controlPrototype->type === 'email'
+			&& $control->getOption('input-prepend') === NULL
+		) {
 			$control->setOption('input-prepend', '@');
 		}
 


### PR DESCRIPTION
It was not possible to change or remove default prepend for form field with type "email". Now you if the "input-prepend" option is set to `FALSE` then it will not be rendered. It can be also changed to anything else then "@".
